### PR TITLE
Update cask to grain v0.3.2

### DIFF
--- a/Casks/grain.rb
+++ b/Casks/grain.rb
@@ -1,8 +1,8 @@
 cask "grain" do
-  version "0.3.0"
-  sha256 "bcc19a6a1faa8ab568dd7377f7531f0a063f5f86ac702e80065cf26d0a6cc5a2"
+  version "0.3.2"
+  sha256 "79d04bda10e088326f9ec7a60226d215f1f8fda1b449cc3fa96c44291f93c10f"
 
-  url "https://github.com/grain-lang/grain/releases/download/grain-v#{version}/grain-mac-x64"
+  url "https://github.com/grain-lang/grain/releases/download/grain-v#{version}/grain-mac-x64", verified: "https://github.com/grain-lang/grain/"
   name "The Grain Programming Language"
   desc "Packaged Grain binary, including the compiler, runtime & stdlib"
   homepage "https://grain-lang.org/"


### PR DESCRIPTION
Tiny PR to update the grain version available via Homebrew.

Verified as follows:

```
$ sha256sum grain-mac-x64-0.3.0
bcc19a6a1faa8ab568dd7377f7531f0a063f5f86ac702e80065cf26d0a6cc5a2  grain-mac-x64-0.3.0

$ sha256sum grain-mac-x64-0.3.2
79d04bda10e088326f9ec7a60226d215f1f8fda1b449cc3fa96c44291f93c10f  grain-mac-x64-0.3.2
```

Happy Friday!