### PR TITLE
fix: Add requires_rosetta caveat

### DIFF
--- a/Casks/grain.rb
+++ b/Casks/grain.rb
@@ -8,4 +8,8 @@ cask "grain" do
   homepage "https://grain-lang.org/"
 
   binary "grain-mac-x64", target: "grain"
+
+  caveats do
+    requires_rosetta
+  end
 end


### PR DESCRIPTION
Looks like the CI failed the audit because we don't have this caveat listed.